### PR TITLE
Try to get at the native OpenGL context instead of the GDI context

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+0.07  - Windows: Try to get at the native OpenGL context, not the
+        default software implementation
+
 0.06  - add alpha layering support
 
 0.05  - small fixes

--- a/win32.c
+++ b/win32.c
@@ -144,7 +144,7 @@ gl_context_create( Handle object, GLRequest * request)
 	memset(&pfd, 0, sizeof(pfd));
 	pfd.nSize        = sizeof(pfd);
 	pfd.nVersion     = 1;
-	pfd.dwFlags      = PFD_SUPPORT_OPENGL | PFD_SUPPORT_GDI;
+	pfd.dwFlags      = PFD_SUPPORT_OPENGL;
 
 	switch ( request-> target ) {
 	case GLREQ_TARGET_BITMAP:
@@ -184,7 +184,7 @@ gl_context_create( Handle object, GLRequest * request)
 		glbm = 0;
 		wnd  = 0;
 		dc   = GetDC( 0 );
-		pfd.dwFlags |= PFD_DRAW_TO_WINDOW;
+		pfd.dwFlags |= PFD_DRAW_TO_WINDOW | PFD_SUPPORT_GDI;
 		layered = false;
 		break;
 	}


### PR DESCRIPTION
This should allow us to request OpenGL functions above API level
1.1 , because the GDI OpenGL context only implements 1.1 functions.

The PFD_SUPPORT_GDI prevents the nVidia OpenGL driver from kicking in. I don't know why the GetDC(0) part does not want to work with the nVidia OpenGL driver, so I moved the constant down there to make t/02_basic.t still pass.

I don't know how to add a meaningful test, except that with this change, Prima::OpenGL now works with my OpenGL::Glew implementation and can now load OpenGL functions from the 3.3 OpenGL standard and later. The long-term plan is to move the OpenGL::Glew implementation into the OpenGL distribution itself, but I want to take small steps here. See https://github.com/corion/app-shadertoy for the temporary experimental stuff I'm trying with OpenGL.
