### PR TITLE
use OpenGL::Config rather than reinvent, protect from place-with-space

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,12 +1,11 @@
-# $Id$
 package MY;
 use strict;
 use ExtUtils::MakeMaker;
 use Config;
 use Prima::Config;
+use OpenGL::Config;
 
 my @libs;
-my @inc;
 my @obj  = ('OpenGL.o');
 
 if ( 
@@ -14,19 +13,19 @@ if (
 	( $^O eq 'cygwin' and $Prima::Config::Config{platform} eq 'win32')
 ) {
 	push @libs, '-L/lib/w32api' if $^O eq 'cygwin';
-	push @libs, '-lopengl32 -lgdi32 -lmsimg32';
+	push @libs, '-lopengl32 -lmsimg32';
+	push @libs, map { "-l$_" } @{$Prima::Config::Config{ldlibs} };
 	push @obj,  'win32.o';
 } elsif ( $^O eq 'darwin') {
 	push @libs, map { "-L$_" } @{$Prima::Config::Config{ldpaths} };
-	push @libs, '-L/opt/X11/lib -lGL';
 	push @obj,  'x11.o';
-	push @inc, "-I/opt/X11/include";
 } else {
-	push @libs, '-lGL';
 	push @obj,  'x11.o';
 }
 
-push @libs, $Prima::Config::Config{libs};
+push @libs, qq{"$Prima::Config::Config{libs}"} if $Prima::Config::Config{libs};
+my $oglc_libs = $OpenGL::Config->{LIBS} || '';
+my $oglc_inc = $OpenGL::Config->{INC} || '';
 
 WriteMakefile(
 	NAME               => 'Prima::OpenGL',
@@ -41,9 +40,9 @@ WriteMakefile(
 	},
 	ABSTRACT_FROM      => 'lib/Prima/OpenGL.pm',
 	AUTHOR             => 'Dmitry Karasik <dmitry@karasik.eu.org>',
-	LIBS               => "@libs",
+	LIBS               => [qq{:nosearch $oglc_libs @libs}],
 	DEFINE             => "$Prima::Config::Config{define}",
-	INC                => "$Prima::Config::Config{inc} @inc -Iinclude",
+	INC                => "$oglc_inc $Prima::Config::Config{inc} -Iinclude",
 	OBJECT             => "@obj",
 	META_MERGE        => {
 		resources => {


### PR DESCRIPTION
With this, P:OGL builds and passes tests, and an example runs. I'll try to get OpenGL::Modern on here, one of its dependencies is broken "in space" which I'll fix separately.