### PR TITLE
Various fixes

### DIFF
--- a/examples/shadertoy.pl
+++ b/examples/shadertoy.pl
@@ -1,9 +1,9 @@
 BEGIN {
-	eval "use OpenGL::Modern;";
+	eval "use OpenGL::Modern 0.0401;";
 	if ( $@) {
 		warn <<DIE;
 ***
-This example needs optional OpenGL::Modern module installed.
+This example needs optional OpenGL::Modern module version 0.0401 installed.
 Please run 'cpan OpenGL::Modern'. If the example still doesn't
 work, please file a bug report!
 ***
@@ -112,7 +112,7 @@ sub init_shader
 	        glGetActiveUniform_c( $program, $index, 16, iv_ptr($length), iv_ptr($size), iv_ptr($type), $name);
 		$length = unpack 'I', $length;
 		$name = substr $name, 0, $length;
-		$uniforms{ $name } = glGetUniformLocation_c( $program, $name);
+		$uniforms{ $name } = glGetUniformLocation($program, $name);
 	}
 }
 

--- a/examples/shadertoy.pl
+++ b/examples/shadertoy.pl
@@ -185,6 +185,7 @@ sub create_gl_widget
 			glDeleteShader( $_ ) for values %shaders;
 	        },
     );
+    die "Failed to create widget" if !$gl_widget->gl_paint_state;
 
     undef $program;
     undef %uniforms;

--- a/x11.c
+++ b/x11.c
@@ -78,9 +78,15 @@ gl_context_create( Handle widget, GLRequest * request)
 		*(attr++) = request-> in; \
 	}
 
-	if ( request-> pixels         == GLREQ_PIXEL_RGBA) *(attr++) = GLX_RGBA;
-	if ( request-> double_buffer  == GLREQ_TRUE) *(attr++) = GLX_DOUBLEBUFFER;
-	if ( request-> stereo         == GLREQ_TRUE) *(attr++) = GLX_STEREO;
+	if ( request-> pixels         == GLREQ_PIXEL_RGBA) {
+		*(attr++) = GLX_RENDER_TYPE;
+		*(attr++) = GLX_RGBA_BIT;
+	}
+	ATTR( double_buffer   , GLX_DOUBLEBUFFER     )
+	if ( request-> stereo         == GLREQ_TRUE) {
+		*(attr++) = GLX_STEREO;
+		*(attr++) = True;
+	}
 	ATTR( layer           , GLX_LEVEL            )
 	ATTR( color_bits      , GLX_BUFFER_SIZE      )
 	ATTR( aux_buffers     , GLX_AUX_BUFFERS      )
@@ -247,7 +253,7 @@ gl_error_string(char * buf, int len)
 	case 0:
 		return NULL;
 	case ERROR_CHOOSE_VISUAL:
-		return "glXChooseVisual: cannot find a requested GL visual";
+		return "glXChooseFBConfig: cannot find a requested GL visual";
 	case ERROR_CREATE_CONTEXT:
 		return "glXCreateContext error";
 	case ERROR_OTHER:

--- a/x11.c
+++ b/x11.c
@@ -75,7 +75,7 @@ gl_context_create( Handle widget, GLRequest * request)
 #define ATTR(in,out) \
 	if ( request-> in) { \
 		*(attr++) = out; \
-		*(attr++) = request-> in; \
+		*(attr++) = request-> in == GLREQ_TRUE ? True : False; \
 	}
 
 	if ( request-> pixels         == GLREQ_PIXEL_RGBA) {


### PR DESCRIPTION
This module doesn't currently work on MacOS and I don't know why, still. This PR doesn't yet fix it. It *does* work on Linux with the OGL:Modern fix.

On the way through that, I noted that the `select_visual` code was using attributes in the style of `glXChooseVisual`, but the `glXChooseFBConfig` needs boolean attr values - compare https://registry.khronos.org/OpenGL-Refpages/gl2.1/xhtml/glXChooseVisual.xml and https://registry.khronos.org/OpenGL-Refpages/gl2.1/xhtml/glXChooseFBConfig.xml

Also a couple of functions in OpenGL::Modern 0.0401 have different names since I've fixed them getting a spurious `_c`.